### PR TITLE
Protobuf 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ jdk: openjdk8
 sudo: false
 
 before_script:
-  # get and build protobuf 2.5.0
-  - wget --output-document $HOME/protobuf-2.5.0.tar.gz https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
+  # get and build protobuf
+  - export PROTOBUF_VERSION=2.6.1
+  - wget --output-document $HOME/protobuf-$PROTOBUF_VERSION.tar.gz https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-$PROTOBUF_VERSION.tar.gz
   - cd $HOME
-  - tar xf protobuf-2.5.0.tar.gz
-  - cd protobuf-2.5.0
+  - tar xf protobuf-$PROTOBUF_VERSION.tar.gz
+  - cd protobuf-$PROTOBUF_VERSION
   - ./configure
   - make -j2
   - cd $TRAVIS_BUILD_DIR
@@ -37,7 +38,7 @@ before_script:
   - echo "</settings>"                                                    >> $HOME/settings.xml
 
   # build jars without tests, as they depend on the built jars
-  - mvn --settings $HOME/settings.xml --activate-profiles babudb-dev --file $TRAVIS_BUILD_DIR/java/pom.xml -Dprotoc.bin=$HOME/protobuf-2.5.0/src/protoc -Dprotoc.include=$HOME/protobuf-2.5.0/src -DskipTests install
+  - mvn --settings $HOME/settings.xml --activate-profiles babudb-dev --file $TRAVIS_BUILD_DIR/java/pom.xml -Dprotoc.bin=$HOME/protobuf-$PROTOBUF_VERSION/src/protoc -Dprotoc.include=$HOME/protobuf-$PROTOBUF_VERSION/src -DskipTests install
 
   # build C++ tests
   - mkdir -p $TRAVIS_BUILD_DIR/cpp/build
@@ -48,7 +49,7 @@ before_script:
 
 script:
   # run Java tests
-  - mvn --settings $HOME/settings.xml --activate-profiles babudb-dev --file $TRAVIS_BUILD_DIR/java/pom.xml -Dprotoc.bin=$HOME/protobuf-2.5.0/src/protoc -Dprotoc.include=$HOME/protobuf-2.5.0/src test
+  - mvn --settings $HOME/settings.xml --activate-profiles babudb-dev --file $TRAVIS_BUILD_DIR/java/pom.xml -Dprotoc.bin=$HOME/protobuf-$PROTOBUF_VERSION/src/protoc -Dprotoc.include=$HOME/protobuf-$PROTOBUF_VERSION/src test
 
   # FIXME: run C++ tests
   # - cd $TRAVIS_BUILD_DIR/cpp/build

--- a/java/README.md
+++ b/java/README.md
@@ -22,7 +22,7 @@ BabuDB - Java Components
   <dependency>
     <groupId>org.xtreemfs.babudb</groupId>
     <artifactId>babudb-core</artifactId>
-    <version>0.5.6</version>
+    <version>0.6.0</version>
     <!-- The shaded version excludes the org.xtreemfs.babudb.sandbox -->
     <!-- package and includes applicable licenses.                   -->
     <!-- <classifier>shaded</classifier>                             -->
@@ -31,7 +31,7 @@ BabuDB - Java Components
   <dependency>
     <groupId>org.xtreemfs.babudb</groupId>
     <artifactId>babudb-replication</artifactId>
-    <version>0.5.6</version>
+    <version>0.6.0</version>
     <!-- The shaded version bundles:                                                 -->
     <!-- - com.google.protobuf:protobuf-java                                         -->
     <!-- - org.xtreemfs.xtreemfs:xtreemfs-flease                                     -->

--- a/java/babudb-core/ChangeLog
+++ b/java/babudb-core/ChangeLog
@@ -70,3 +70,7 @@
 2011-12-01: release 0.5.6
   * fixed bug that caused an infinite blocking of external threads on full insertion queues
   * fixed bug that could cause an IllegalMonitorStateException to be raised when creating a checkpoint while manually shutting down a database
+
+2018-03-19: release 0.6.0
+  * bug fix where memory mapped files were not properly unmapped
+  * update Protobuf to 2.6.1

--- a/java/babudb-core/pom.xml
+++ b/java/babudb-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.babudb</groupId>
     <artifactId>babudb-parent</artifactId>
-    <version>0.5.6</version>
+    <version>0.6.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/java/babudb-core/src/main/java/org/xtreemfs/babudb/BabuDBFactory.java
+++ b/java/babudb-core/src/main/java/org/xtreemfs/babudb/BabuDBFactory.java
@@ -32,7 +32,7 @@ public final class BabuDBFactory {
     /**
      * Version (name)
      */
-    public static final String BABUDB_VERSION           = "0.5.6";
+    public static final String BABUDB_VERSION           = "0.6.0";
     
     /**
      * Version of the DB on-disk format (to detect incompatibilities).

--- a/java/babudb-core/src/main/java/org/xtreemfs/babudb/api/dev/plugin/PluginMain.java
+++ b/java/babudb-core/src/main/java/org/xtreemfs/babudb/api/dev/plugin/PluginMain.java
@@ -86,14 +86,18 @@ public abstract class PluginMain {
         int[] babu = new int[] { Integer.parseInt(b[0]), Integer.parseInt(b[1]),
                                  Integer.parseInt(b[2])};
         
-        for (int i = 0; i < 3; i++) {
-            if (babu[i] > to[i] || babu[i] < from[i]) {
+        boolean checkFrom = true, checkTo = true;
+        for (int i = 0; i < 3 && (checkFrom || checkTo); i++) {
+            if ((checkTo && babu[i] > to[i]) || (checkFrom && babu[i] < from[i])) {
                 throw new BabuDBException(ErrorCode.BROKEN_PLUGIN, "This " +
                 		"BabuDB ("+BabuDBFactory.BABUDB_VERSION+") " +
                 	        "is not compatible with this plugin (" + 
                 	        getClass().getName() + "), which requires " +
                 	        "BabuDB to meet " + compatibleBabuDBVersion());
             }
+            // only continue checking if necessary
+            checkTo &= babu[i] == to[i];
+            checkFrom &= babu[i] == from[i];
         }
         return start(babuDB, configPath);
     }

--- a/java/babudb-replication/pom.xml
+++ b/java/babudb-replication/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.babudb</groupId>
     <artifactId>babudb-parent</artifactId>
-    <version>0.5.6</version>
+    <version>0.6.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/java/babudb-replication/pom.xml
+++ b/java/babudb-replication/pom.xml
@@ -19,7 +19,7 @@
     <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
-    <protobuf-java.version>2.5.0</protobuf-java.version>
+    <protobuf-java.version>2.6.1</protobuf-java.version>
     <protoc.bin>/usr/bin/protoc</protoc.bin>
     <protoc.include>/usr/include</protoc.include>
   </properties>

--- a/java/babudb-replication/src/main/java/org/xtreemfs/babudb/replication/Main.java
+++ b/java/babudb-replication/src/main/java/org/xtreemfs/babudb/replication/Main.java
@@ -74,7 +74,7 @@ public class Main extends PluginMain {
      */
     @Override
     public String compatibleBabuDBVersion() {
-        return PluginMain.buildCompatibleVersionString(0, 5, 4, 0, 5, 9);
+        return PluginMain.buildCompatibleVersionString(0, 5, 4, 0, 6, 0);
     }
 
     /* (non-Javadoc)

--- a/java/babudb-replication/src/test/resources/config/replication.properties
+++ b/java/babudb-replication/src/test/resources/config/replication.properties
@@ -2,7 +2,7 @@
 # BabuDB replication plugin configuration					   		#
 #####################################################################
 
-plugin.jar = target/babudb-replication-0.5.6.jar
+plugin.jar = target/babudb-replication-0.6.0.jar
 
 # DB backup directory - needed for the initial loading of the BabuDB from the 
 # master in replication context

--- a/java/babudb-replication/src/test/resources/config/replication_server0.test
+++ b/java/babudb-replication/src/test/resources/config/replication_server0.test
@@ -2,7 +2,7 @@
 # BabuDB replication configuration								   								#
 #####################################################################
 
-plugin.jar = target/babudb-replication-0.5.6.jar
+plugin.jar = target/babudb-replication-0.6.0.jar
 
 # DB backup directory - needed for the initial loading of the BabuDB from the 
 # master in replication context

--- a/java/babudb-replication/src/test/resources/config/replication_server1.test
+++ b/java/babudb-replication/src/test/resources/config/replication_server1.test
@@ -2,7 +2,7 @@
 # BabuDB replication configuration								   								#
 #####################################################################
 
-plugin.jar = target/babudb-replication-0.5.6.jar
+plugin.jar = target/babudb-replication-0.6.0.jar
 
 # DB backup directory - needed for the initial loading of the BabuDB from the 
 # master in replication context

--- a/java/babudb-replication/src/test/resources/config/replication_server2.test
+++ b/java/babudb-replication/src/test/resources/config/replication_server2.test
@@ -2,7 +2,7 @@
 # BabuDB replication configuration								   								#
 #####################################################################
 
-plugin.jar = target/babudb-replication-0.5.6.jar
+plugin.jar = target/babudb-replication-0.6.0.jar
 
 # DB backup directory - needed for the initial loading of the BabuDB from the 
 # master in replication context

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.xtreemfs.babudb</groupId>
   <artifactId>babudb-parent</artifactId>
-  <version>0.5.6</version>
+  <version>0.6.0</version>
 
   <name>babudb</name>
   <packaging>pom</packaging>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,8 +35,7 @@
 
     <!-- Compile dependencies. -->
     <commons-codec.version>1.3</commons-codec.version>
-    <protobuf-java.version>2.5.0</protobuf-java.version>
-    <xtreemfs.version>1.5.1-SNAPSHOT</xtreemfs.version>
+    <xtreemfs.version>1.6.0-SNAPSHOT</xtreemfs.version>
 
     <!-- Test dependencies. -->
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
This PR updates the Protobuf dependency to 2.6.1. It furthermore updates the XtreemFS dependency to 1.6.0-SNAPSHOT. As a minor update, the plugin version range check has been fixed.